### PR TITLE
여행 일정표 생성,수정,삭제,조회 기능 

### DIFF
--- a/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
@@ -65,8 +65,12 @@ public class PlanController {
 
   // 여행 일정 삭제
   @DeleteMapping("{planId}")
-  public ResponseEntity<?> deletePlan(@PathVariable Long planId) {
+  public ResponseEntity<?> deletePlan(
+      @PathVariable Long planId,
+      @AuthenticationPrincipal UserDetails userDetails) {
 
+    String userId = userDetails.getUsername();
+    planService.deletePlan(planId, userId);
     return ResponseEntity.ok("여행 일정 삭제 성공");
   }
 

--- a/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
@@ -1,14 +1,19 @@
 package com.eunsun.travel_mate.controller;
 
+import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
 import com.eunsun.travel_mate.service.PlanService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,14 +27,21 @@ public class PlanController {
 
   // 여행 일정 생성
   @PostMapping
-  public ResponseEntity<?> createPlan() {
+  public ResponseEntity<?> createPlan(
+      @RequestBody CreatePlanRequest createPlanRequest,
+      @AuthenticationPrincipal UserDetails userDetails) {
 
-    return ResponseEntity.ok("여행 일정 생성 성공");
+    String userId = userDetails.getUsername();
+    CreatePlanResponseDto createPlanId = planService.createPlan(createPlanRequest, userId);
+
+    return ResponseEntity.ok(createPlanId);
   }
 
   // 여행 일정 조회
   @GetMapping("{planId}")
-  public ResponseEntity<?> getPlan(@PathVariable Long planId) {
+  public ResponseEntity<?> getPlan(
+      @PathVariable Long planId,
+      @AuthenticationPrincipal UserDetails userDetails) {
 
     return ResponseEntity.ok("여행 일정 조회 성공");
   }

--- a/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
@@ -1,8 +1,10 @@
 package com.eunsun.travel_mate.controller;
 
 import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.request.UpdatePlanRequestDto;
 import com.eunsun.travel_mate.dto.response.CheckPlanResponseDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanResponseDto;
 import com.eunsun.travel_mate.service.PlanService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,9 +53,14 @@ public class PlanController {
 
   // 여행 일정 수정
   @PutMapping("{planId}")
-  public ResponseEntity<?> updatePlan(@PathVariable Long planId) {
+  public ResponseEntity<?> updatePlan(
+      @PathVariable Long planId,
+      @AuthenticationPrincipal UserDetails userDetails,
+      @RequestBody UpdatePlanRequestDto updatePlanRequestDto) {
 
-    return ResponseEntity.ok("여행 일정 수정 성공");
+    String userId = userDetails.getUsername();
+    UpdatePlanResponseDto updatePlanResponse = planService.updatePlan(planId, userId, updatePlanRequestDto);
+    return ResponseEntity.ok(updatePlanResponse);
   }
 
   // 여행 일정 삭제

--- a/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanController.java
@@ -1,6 +1,7 @@
 package com.eunsun.travel_mate.controller;
 
 import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.response.CheckPlanResponseDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
 import com.eunsun.travel_mate.service.PlanService;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,9 @@ public class PlanController {
       @PathVariable Long planId,
       @AuthenticationPrincipal UserDetails userDetails) {
 
-    return ResponseEntity.ok("여행 일정 조회 성공");
+    String userId = userDetails.getUsername();
+    CheckPlanResponseDto planResponseDto = planService.getPlan(planId, userId);
+    return ResponseEntity.ok(planResponseDto);
   }
 
   // 여행 일정 수정

--- a/src/main/java/com/eunsun/travel_mate/controller/PlanDetailController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanDetailController.java
@@ -1,14 +1,18 @@
 package com.eunsun.travel_mate.controller;
 
+import com.eunsun.travel_mate.dto.request.CreatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.response.CreatePlanDetailResponseDto;
 import com.eunsun.travel_mate.service.PlanDetailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,17 +26,15 @@ public class PlanDetailController {
 
   // 여행 상세 일정 생성
   @PostMapping
-  public ResponseEntity<?> createPlanDetail(@PathVariable Long planId) {
+  public ResponseEntity<?> createPlanDetail(
+      @PathVariable Long planId,
+      @RequestBody CreatePlanDetailRequestDto createPlanDetailRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails) {
 
-    return ResponseEntity.ok("여행 상세 일정 생성");
+    String userId = userDetails.getUsername();
+    CreatePlanDetailResponseDto createPlanDetailResponseDto = planDetailService.createPlanDetail(planId, createPlanDetailRequestDto, userId);
+    return ResponseEntity.ok(createPlanDetailResponseDto);
 
-  }
-
-  // 여행 상세 일정 조회
-  @GetMapping("/{planDetailId}")
-  public ResponseEntity<?> getPlanDetail(@PathVariable Long planId, @PathVariable Long planDetailId) {
-
-    return ResponseEntity.ok("여행 상세 일정 조회");
   }
 
   // 여행 상세 일정 수정

--- a/src/main/java/com/eunsun/travel_mate/controller/PlanDetailController.java
+++ b/src/main/java/com/eunsun/travel_mate/controller/PlanDetailController.java
@@ -1,7 +1,9 @@
 package com.eunsun.travel_mate.controller;
 
 import com.eunsun.travel_mate.dto.request.CreatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.request.UpdatePlanDetailRequestDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanDetailResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanDetailResponseDto;
 import com.eunsun.travel_mate.service.PlanDetailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,15 +41,26 @@ public class PlanDetailController {
 
   // 여행 상세 일정 수정
   @PutMapping("/{planDetailId}")
-  public ResponseEntity<?> updatePlanDetail(@PathVariable Long planId, @PathVariable Long planDetailId) {
+  public ResponseEntity<?> updatePlanDetail(
+      @PathVariable Long planId,
+      @PathVariable("planDetailId") Long planDetailId,
+      @AuthenticationPrincipal UserDetails userDetails,
+      @RequestBody UpdatePlanDetailRequestDto updatePlanDetailRequestDto) {
 
-    return ResponseEntity.ok("여행 상세 일정 수정");
+    String userId = userDetails.getUsername();
+    UpdatePlanDetailResponseDto updatePlanDetailResponse = planDetailService.updatePlanDetail(planId, planDetailId, userId, updatePlanDetailRequestDto);
+    return ResponseEntity.ok(updatePlanDetailResponse);
   }
 
   // 여행 상세 일정 삭제
   @DeleteMapping("/{planDetailId}")
-  public ResponseEntity<?> deletePlanDetail(@PathVariable Long planId, @PathVariable Long planDetailId) {
+  public ResponseEntity<?> deletePlanDetail(
+      @PathVariable Long planId,
+      @PathVariable("planDetailId") Long planDetailId,
+      @AuthenticationPrincipal UserDetails userDetails) {
 
-    return ResponseEntity.ok("여행 상세 일정 삭제");
+    String userId = userDetails.getUsername();
+    planDetailService.deletePlanDetail(planDetailId, planId, userId);
+    return ResponseEntity.ok("여행 상세 일정 삭제 성공");
   }
 }

--- a/src/main/java/com/eunsun/travel_mate/domain/Plan.java
+++ b/src/main/java/com/eunsun/travel_mate/domain/Plan.java
@@ -1,5 +1,6 @@
 package com.eunsun.travel_mate.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -36,7 +37,7 @@ public class Plan extends Base {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @OneToMany(mappedBy = "plan", fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "plan", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
   private List<PlanDetail> planDetails = new ArrayList<>();
 
   @Column(nullable = false)

--- a/src/main/java/com/eunsun/travel_mate/domain/Plan.java
+++ b/src/main/java/com/eunsun/travel_mate/domain/Plan.java
@@ -2,13 +2,19 @@ package com.eunsun.travel_mate.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +23,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "plan")
 public class Plan extends Base {
 
@@ -28,13 +36,16 @@ public class Plan extends Base {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  @OneToMany(mappedBy = "plan", fetch = FetchType.EAGER)
+  private List<PlanDetail> planDetails = new ArrayList<>();
+
   @Column(nullable = false)
   private String title;
 
   @Column(nullable = false)
-  private LocalDate startDate;
+  private LocalDate startDate; // 여행 시작 날짜
 
   @Column(nullable = false)
-  private LocalDate endDate;
+  private LocalDate endDate; // 여행 끝나는 날짜
 
 }

--- a/src/main/java/com/eunsun/travel_mate/domain/PlanDetail.java
+++ b/src/main/java/com/eunsun/travel_mate/domain/PlanDetail.java
@@ -14,9 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/eunsun/travel_mate/domain/PlanDetail.java
+++ b/src/main/java/com/eunsun/travel_mate/domain/PlanDetail.java
@@ -9,16 +9,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "plan_detail")
 public class PlanDetail extends Base {
 
@@ -33,12 +34,6 @@ public class PlanDetail extends Base {
   @ManyToOne
   @JoinColumn(name = "tour_info_id", nullable = false)
   private TourInfo tourInfo;
-
-  @Column(nullable = false)
-  private LocalDate startDate;
-
-  @Column(nullable = false)
-  private LocalDate endDate;
 
   @Column(nullable = false)
   private LocalTime startTime;

--- a/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanDetailRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanDetailRequestDto.java
@@ -1,0 +1,22 @@
+package com.eunsun.travel_mate.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanDetailRequestDto{
+
+  private Long tourInfoId;
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime startTime;
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime endTime;
+
+  private String memo;
+}
+

--- a/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanDetailRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanDetailRequestDto.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class CreatePlanDetailRequestDto{
 

--- a/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanRequest.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanRequest.java
@@ -1,0 +1,17 @@
+package com.eunsun.travel_mate.dto.request;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanRequest {
+
+  private String title;
+
+  // yyyy-MM-dd 형식으로
+  private LocalDate startDate;
+  private LocalDate endDate;
+
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanRequest.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/CreatePlanRequest.java
@@ -3,8 +3,10 @@ package com.eunsun.travel_mate.dto.request;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class CreatePlanRequest {
 

--- a/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
@@ -1,0 +1,20 @@
+package com.eunsun.travel_mate.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePlanDetailRequestDto {
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime startTime;
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime endTime;
+
+  private String memo;
+
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdatePlanDetailRequestDto {
 
+  private Long tourInfoId;
+
   @JsonFormat(pattern = "HH:mm")
   private LocalTime startTime;
 

--- a/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanDetailRequestDto.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class UpdatePlanDetailRequestDto {
 

--- a/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanRequestDto.java
@@ -3,8 +3,10 @@ package com.eunsun.travel_mate.dto.request;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class UpdatePlanRequestDto {
 

--- a/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanRequestDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/request/UpdatePlanRequestDto.java
@@ -1,0 +1,15 @@
+package com.eunsun.travel_mate.dto.request;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePlanRequestDto {
+
+  private String title;
+  private LocalDate startDate;
+  private LocalDate endDate;
+
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/CheckPlanDetailResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/CheckPlanDetailResponseDto.java
@@ -1,0 +1,31 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.PlanDetail;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CheckPlanDetailResponseDto {
+
+  private Long planDetailId;
+  private Long tourInfoId;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private String memo;
+
+  public static CheckPlanDetailResponseDto from(PlanDetail planDetail) {
+    return CheckPlanDetailResponseDto.builder()
+        .planDetailId(planDetail.getPlanDetailId())
+        .tourInfoId(planDetail.getTourInfo().getTourInfoId())
+        .startTime(planDetail.getStartTime())
+        .endTime(planDetail.getEndTime())
+        .memo(planDetail.getMemo())
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/CheckPlanResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/CheckPlanResponseDto.java
@@ -1,0 +1,39 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.Plan;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CheckPlanResponseDto {
+
+  private Long planId;
+  private String title;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private List<CheckPlanDetailResponseDto> planDetails;
+
+  public static CheckPlanResponseDto from(Plan plan) {
+    List<CheckPlanDetailResponseDto> checkPlanDetailResponseDto = plan.getPlanDetails().stream()
+        .map(CheckPlanDetailResponseDto::from)
+        .sorted(Comparator.comparing(CheckPlanDetailResponseDto::getStartTime))
+        .collect(Collectors.toList());
+
+    return CheckPlanResponseDto.builder()
+        .planId(plan.getPlanId())
+        .title(plan.getTitle())
+        .startDate(plan.getStartDate())
+        .endDate(plan.getEndDate())
+        .planDetails(checkPlanDetailResponseDto)
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/CreatePlanDetailResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/CreatePlanDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.PlanDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreatePlanDetailResponseDto {
+  private Long planDetailId;
+  private String message;
+
+  public static CreatePlanDetailResponseDto from(PlanDetail planDetail) {
+    return CreatePlanDetailResponseDto.builder()
+        .planDetailId(planDetail.getPlanDetailId())
+        .message("여행 상제 일정표 생성 성공")
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/CreatePlanResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/CreatePlanResponseDto.java
@@ -1,0 +1,24 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.Plan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreatePlanResponseDto {
+
+  private Long planId;
+  private String message;
+
+  public static CreatePlanResponseDto from(Plan plan) {
+    return CreatePlanResponseDto.builder()
+        .planId(plan.getPlanId())
+        .message("여행 일정표 생성 성공")
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanDetailResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanDetailResponseDto.java
@@ -1,0 +1,32 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.PlanDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdatePlanDetailResponseDto {
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime startTime;
+
+  @JsonFormat(pattern = "HH:mm")
+  private LocalTime endTime;
+
+  private String memo;
+
+  public static UpdatePlanDetailResponseDto from(PlanDetail planDetail) {
+    return UpdatePlanDetailResponseDto.builder()
+        .startTime(planDetail.getStartTime())
+        .endTime(planDetail.getEndTime())
+        .memo(planDetail.getMemo())
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanDetailResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanDetailResponseDto.java
@@ -14,6 +14,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UpdatePlanDetailResponseDto {
 
+  private Long tourInfoId;
+  private String tourInfoName;
+
   @JsonFormat(pattern = "HH:mm")
   private LocalTime startTime;
 
@@ -24,6 +27,8 @@ public class UpdatePlanDetailResponseDto {
 
   public static UpdatePlanDetailResponseDto from(PlanDetail planDetail) {
     return UpdatePlanDetailResponseDto.builder()
+        .tourInfoId(planDetail.getTourInfo().getTourInfoId())
+        .tourInfoName(planDetail.getTourInfo().getTitle())
         .startTime(planDetail.getStartTime())
         .endTime(planDetail.getEndTime())
         .memo(planDetail.getMemo())

--- a/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanResponseDto.java
+++ b/src/main/java/com/eunsun/travel_mate/dto/response/UpdatePlanResponseDto.java
@@ -1,0 +1,29 @@
+package com.eunsun.travel_mate.dto.response;
+
+import com.eunsun.travel_mate.domain.Plan;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdatePlanResponseDto {
+
+  private Long planId;
+  private String title;
+  private LocalDate startDate;
+  private LocalDate endDate;
+
+  public static UpdatePlanResponseDto from(Plan plan) {
+    return UpdatePlanResponseDto.builder()
+        .planId(plan.getPlanId())
+        .title(plan.getTitle())
+        .startDate(plan.getStartDate())
+        .endDate(plan.getEndDate())
+        .build();
+  }
+}

--- a/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
@@ -1,6 +1,13 @@
 package com.eunsun.travel_mate.service;
 
+import com.eunsun.travel_mate.domain.Plan;
+import com.eunsun.travel_mate.domain.PlanDetail;
+import com.eunsun.travel_mate.domain.tourInfo.TourInfo;
+import com.eunsun.travel_mate.dto.request.CreatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.response.CreatePlanDetailResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanDetailRepository;
+import com.eunsun.travel_mate.repository.jpa.PlanRepository;
+import com.eunsun.travel_mate.repository.jpa.TourInfoRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,6 +17,37 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class PlanDetailService {
 
+  private final TourInfoRepository tourInfoRepository;
+  private final PlanRepository planRepository;
   private final PlanDetailRepository planDetailRepository;
 
+  // 여행 상세 일정 생성
+  public CreatePlanDetailResponseDto createPlanDetail(Long planId, CreatePlanDetailRequestDto createPlanDetailRequestDto, String userId) {
+
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    TourInfo tourInfo = tourInfoRepository.findById(createPlanDetailRequestDto.getTourInfoId())
+        .orElseThrow(() -> new IllegalArgumentException("여행지 정보를 찾을 수 없습니다."));
+
+    PlanDetail planDetail = PlanDetail.builder()
+        .plan(plan)
+        .tourInfo(tourInfo)
+        .startTime(createPlanDetailRequestDto.getStartTime())
+        .endTime(createPlanDetailRequestDto.getEndTime())
+        .memo(createPlanDetailRequestDto.getMemo())
+        .build();
+
+    planDetailRepository.save(planDetail);
+    CreatePlanDetailResponseDto responseDto = CreatePlanDetailResponseDto.from(planDetail);
+    log.info("여행 상세 일정표 생성 성공");
+
+    return responseDto;
+
+  }
 }

--- a/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
@@ -65,6 +65,12 @@ public class PlanDetailService {
     PlanDetail planDetail = planDetailRepository.findById(planDetailId)
         .orElseThrow(() -> new IllegalArgumentException("상세 일정을 찾을 수 없습니다."));
 
+    if (updatePlanDetailRequestDto.getTourInfoId() != null) {
+      TourInfo newTourInfo = tourInfoRepository.findById(updatePlanDetailRequestDto.getTourInfoId())
+          .orElseThrow(() -> new IllegalArgumentException("여행지 정보를 찾을 수 없습니다."));
+      planDetail.setTourInfo(newTourInfo);
+    }
+
     // 사용자 정보 확인
     if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
       throw new IllegalArgumentException("접근 권한이 없습니다.");

--- a/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
@@ -4,13 +4,16 @@ import com.eunsun.travel_mate.domain.Plan;
 import com.eunsun.travel_mate.domain.PlanDetail;
 import com.eunsun.travel_mate.domain.tourInfo.TourInfo;
 import com.eunsun.travel_mate.dto.request.CreatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.request.UpdatePlanDetailRequestDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanDetailResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanDetailResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanDetailRepository;
 import com.eunsun.travel_mate.repository.jpa.PlanRepository;
 import com.eunsun.travel_mate.repository.jpa.TourInfoRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -49,5 +52,61 @@ public class PlanDetailService {
 
     return responseDto;
 
+  }
+
+  // 여행 상세 일정 수정
+
+  @Transactional
+  public UpdatePlanDetailResponseDto updatePlanDetail(Long planId, Long planDetailId, String userId, UpdatePlanDetailRequestDto updatePlanDetailRequestDto) {
+
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    PlanDetail planDetail = planDetailRepository.findById(planDetailId)
+        .orElseThrow(() -> new IllegalArgumentException("상세 일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    // 상세 일정 정보 업데이트 - 부분 수정 가능
+    if (updatePlanDetailRequestDto.getStartTime() != null) {
+      planDetail.setStartTime(updatePlanDetailRequestDto.getStartTime());
+    }
+
+    if (updatePlanDetailRequestDto.getEndTime() != null) {
+      planDetail.setEndTime(updatePlanDetailRequestDto.getEndTime());
+    }
+
+    if (updatePlanDetailRequestDto.getMemo() != null) {
+      planDetail.setMemo(updatePlanDetailRequestDto.getMemo());
+    }
+
+    UpdatePlanDetailResponseDto responseDto = UpdatePlanDetailResponseDto.from(planDetail);
+    log.info("여행 일정 정보 수정 성공");
+
+    return responseDto;
+
+  }
+
+  // 여행 상세 일정 삭제
+  @Transactional
+  public void deletePlanDetail(Long planDetailId, Long planId, String userId) {
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    PlanDetail planDetail = planDetailRepository.findById(planDetailId)
+        .orElseThrow(() -> new IllegalArgumentException("상세 일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    plan.getPlanDetails().remove(planDetail);
+    planDetailRepository.delete(planDetail);
+
+    log.info("여행 상세 일정 삭제 성공");
   }
 }

--- a/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanDetailService.java
@@ -46,8 +46,8 @@ public class PlanDetailService {
         .memo(createPlanDetailRequestDto.getMemo())
         .build();
 
-    planDetailRepository.save(planDetail);
-    CreatePlanDetailResponseDto responseDto = CreatePlanDetailResponseDto.from(planDetail);
+    PlanDetail planDetail1 = planDetailRepository.save(planDetail);
+    CreatePlanDetailResponseDto responseDto = CreatePlanDetailResponseDto.from(planDetail1);
     log.info("여행 상세 일정표 생성 성공");
 
     return responseDto;

--- a/src/main/java/com/eunsun/travel_mate/service/PlanService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanService.java
@@ -9,6 +9,7 @@ import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
 import com.eunsun.travel_mate.dto.response.UpdatePlanResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanRepository;
 import com.eunsun.travel_mate.repository.jpa.UserRepository;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -28,6 +29,21 @@ public class PlanService {
   public CreatePlanResponseDto createPlan(CreatePlanRequest createPlanRequest, String userId) {
     User user = userRepository.findById(Long.valueOf(userId))
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+    String title = createPlanRequest.getTitle();
+    if (title == null || title.isBlank()) {
+      throw new IllegalArgumentException("제목을 입력해주세요.");
+    }
+
+    LocalDate startDate = createPlanRequest.getStartDate();
+    if (startDate == null) {
+      throw new IllegalArgumentException("시작 날짜를 입력해주세요.");
+    }
+
+    LocalDate endDate = createPlanRequest.getEndDate();
+    if (endDate == null) {
+      throw new IllegalArgumentException("종료 날짜를 입력해주세요.");
+    }
 
     Plan plan = Plan.builder()
         .user(user)

--- a/src/main/java/com/eunsun/travel_mate/service/PlanService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanService.java
@@ -1,8 +1,14 @@
 package com.eunsun.travel_mate.service;
 
+import com.eunsun.travel_mate.domain.Plan;
+import com.eunsun.travel_mate.domain.User;
+import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanRepository;
+import com.eunsun.travel_mate.repository.jpa.UserRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,5 +16,28 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class PlanService {
 
+  private final UserRepository userRepository;
   private final PlanRepository planRepository;
+
+
+  // 여행 일정표 생성
+  public CreatePlanResponseDto createPlan(CreatePlanRequest createPlanRequest, String userId) {
+    User user = userRepository.findById(Long.valueOf(userId))
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+    Plan plan = Plan.builder()
+        .user(user)
+        .title(createPlanRequest.getTitle())
+        .startDate(createPlanRequest.getStartDate())
+        .endDate(createPlanRequest.getEndDate())
+        .build();
+
+    planRepository.save(plan);
+    CreatePlanResponseDto responseDto = CreatePlanResponseDto.from(plan);
+    log.info("여행 일정 생성 성공");
+
+    return responseDto;
+  }
+
+
 }

--- a/src/main/java/com/eunsun/travel_mate/service/PlanService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanService.java
@@ -3,6 +3,7 @@ package com.eunsun.travel_mate.service;
 import com.eunsun.travel_mate.domain.Plan;
 import com.eunsun.travel_mate.domain.User;
 import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.response.CheckPlanResponseDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanRepository;
 import com.eunsun.travel_mate.repository.jpa.UserRepository;
@@ -40,4 +41,16 @@ public class PlanService {
   }
 
 
+  // 여행 일정표 조회
+  public CheckPlanResponseDto getPlan(Long planId, String userId) {
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    return CheckPlanResponseDto.from(plan);
+  }
 }

--- a/src/main/java/com/eunsun/travel_mate/service/PlanService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanService.java
@@ -54,7 +54,9 @@ public class PlanService {
       throw new IllegalArgumentException("접근 권한이 없습니다.");
     }
 
-    return CheckPlanResponseDto.from(plan);
+    CheckPlanResponseDto responseDto = CheckPlanResponseDto.from(plan);
+    log.info("여행 일정 조회 성공");
+    return responseDto;
   }
 
   // 여행 일정 수정
@@ -69,7 +71,7 @@ public class PlanService {
       throw new IllegalArgumentException("접근 권한이 없습니다.");
     }
 
-    // 일정 정보 업데이트
+    // 일정 정보 업데이트 - 부분 수정 가능
     if (updatePlanRequestDto.getTitle() != null) {
       plan.setTitle(updatePlanRequestDto.getTitle());
     }
@@ -81,8 +83,24 @@ public class PlanService {
     }
 
     UpdatePlanResponseDto responseDto = UpdatePlanResponseDto.from(plan);
-    log.info("일정 정보 수정 성공");
+    log.info("여행 일정 정보 수정 성공");
 
     return responseDto;
+  }
+
+  // 일정표 삭제하기
+  @Transactional
+  public void deletePlan(Long planId, String userId) {
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    planRepository.delete(plan);
+    log.info("여행 일정 삭제 성공");
+
   }
 }

--- a/src/main/java/com/eunsun/travel_mate/service/PlanService.java
+++ b/src/main/java/com/eunsun/travel_mate/service/PlanService.java
@@ -3,14 +3,17 @@ package com.eunsun.travel_mate.service;
 import com.eunsun.travel_mate.domain.Plan;
 import com.eunsun.travel_mate.domain.User;
 import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.request.UpdatePlanRequestDto;
 import com.eunsun.travel_mate.dto.response.CheckPlanResponseDto;
 import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanResponseDto;
 import com.eunsun.travel_mate.repository.jpa.PlanRepository;
 import com.eunsun.travel_mate.repository.jpa.UserRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -41,7 +44,7 @@ public class PlanService {
   }
 
 
-  // 여행 일정표 조회
+  // 여행 일정표 조회 - PlanDetail 같이 조회
   public CheckPlanResponseDto getPlan(Long planId, String userId) {
     Plan plan = planRepository.findById(planId)
         .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
@@ -52,5 +55,34 @@ public class PlanService {
     }
 
     return CheckPlanResponseDto.from(plan);
+  }
+
+  // 여행 일정 수정
+  @Transactional
+  public UpdatePlanResponseDto updatePlan(Long planId, String userId, UpdatePlanRequestDto updatePlanRequestDto) {
+
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+    // 사용자 정보 확인
+    if (!plan.getUser().getUserId().equals(Long.valueOf(userId))) {
+      throw new IllegalArgumentException("접근 권한이 없습니다.");
+    }
+
+    // 일정 정보 업데이트
+    if (updatePlanRequestDto.getTitle() != null) {
+      plan.setTitle(updatePlanRequestDto.getTitle());
+    }
+    if (updatePlanRequestDto.getStartDate() != null) {
+      plan.setStartDate(updatePlanRequestDto.getStartDate());
+    }
+    if (updatePlanRequestDto.getEndDate() != null) {
+      plan.setEndDate(updatePlanRequestDto.getEndDate());
+    }
+
+    UpdatePlanResponseDto responseDto = UpdatePlanResponseDto.from(plan);
+    log.info("일정 정보 수정 성공");
+
+    return responseDto;
   }
 }

--- a/src/test/java/com/eunsun/travel_mate/service/FavoriteServiceTest.java
+++ b/src/test/java/com/eunsun/travel_mate/service/FavoriteServiceTest.java
@@ -1,8 +1,14 @@
 package com.eunsun.travel_mate.service;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.eunsun.travel_mate.domain.Favorite;
 import com.eunsun.travel_mate.domain.User;

--- a/src/test/java/com/eunsun/travel_mate/service/PlanDetailServiceTest.java
+++ b/src/test/java/com/eunsun/travel_mate/service/PlanDetailServiceTest.java
@@ -1,0 +1,127 @@
+package com.eunsun.travel_mate.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eunsun.travel_mate.domain.Plan;
+import com.eunsun.travel_mate.domain.PlanDetail;
+import com.eunsun.travel_mate.domain.User;
+import com.eunsun.travel_mate.domain.tourInfo.TourInfo;
+import com.eunsun.travel_mate.dto.request.CreatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.request.UpdatePlanDetailRequestDto;
+import com.eunsun.travel_mate.dto.response.CreatePlanDetailResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanDetailResponseDto;
+import com.eunsun.travel_mate.repository.jpa.PlanDetailRepository;
+import com.eunsun.travel_mate.repository.jpa.PlanRepository;
+import com.eunsun.travel_mate.repository.jpa.TourInfoRepository;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlanDetailServiceTest {
+
+  @InjectMocks
+  private PlanDetailService planDetailService;
+
+  @Mock
+  private TourInfoRepository tourInfoRepository;
+
+  @Mock
+  private PlanRepository planRepository;
+
+  @Mock
+  private PlanDetailRepository planDetailRepository;
+
+  private Plan plan;
+  private TourInfo tourInfo;
+  private PlanDetail planDetail;
+
+  @BeforeEach
+  void setUp() {
+    User user = User.builder().userId(1L).build();
+    plan = Plan.builder().planId(1L).user(user).build();
+    tourInfo = TourInfo.builder().tourInfoId(1L).build();
+    planDetail = PlanDetail.builder().planDetailId(1L).plan(plan).tourInfo(tourInfo).build();
+  }
+
+  @Test
+  @DisplayName("상세 일정 생성 테스트")
+  void createPlanDetail() {
+    // given
+    CreatePlanDetailRequestDto requestDto = new CreatePlanDetailRequestDto();
+    requestDto.setTourInfoId(1L);
+    requestDto.setStartTime(LocalTime.of(10, 0));
+    requestDto.setEndTime(LocalTime.of(12, 0));
+    requestDto.setMemo("테스트 메모");
+
+    when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
+    when(tourInfoRepository.findById(1L)).thenReturn(Optional.of(tourInfo));
+    when(planDetailRepository.save(any(PlanDetail.class))).thenReturn(planDetail);
+
+    // when
+    CreatePlanDetailResponseDto responseDto = planDetailService.createPlanDetail(1L, requestDto, "1");
+
+    // then
+    assertNotNull(responseDto);
+    assertEquals(1L, responseDto.getPlanDetailId());
+    verify(planDetailRepository).save(any(PlanDetail.class));
+  }
+
+  @Test
+  @DisplayName("상세 일정 수정 테스트")
+  void updatePlanDetail() {
+    // given
+    UpdatePlanDetailRequestDto requestDto = new UpdatePlanDetailRequestDto();
+    requestDto.setTourInfoId(2L);
+    requestDto.setStartTime(LocalTime.of(11, 0));
+    requestDto.setEndTime(LocalTime.of(13, 0));
+    requestDto.setMemo("수정된 메모");
+
+    TourInfo updatedTourInfo = TourInfo.builder().tourInfoId(2L).build();
+
+    when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
+    when(planDetailRepository.findById(1L)).thenReturn(Optional.of(planDetail));
+    when(tourInfoRepository.findById(2L)).thenReturn(Optional.of(updatedTourInfo));
+
+    // when
+    UpdatePlanDetailResponseDto responseDto = planDetailService.updatePlanDetail(1L, 1L, "1", requestDto);
+
+    // then
+    assertNotNull(responseDto);
+    assertEquals(2L, responseDto.getTourInfoId());
+    assertEquals(LocalTime.of(11, 0), responseDto.getStartTime());
+    assertEquals(LocalTime.of(13, 0), responseDto.getEndTime());
+    assertEquals("수정된 메모", responseDto.getMemo());
+  }
+
+  @Test
+  @DisplayName("상세 일정 삭제 테스트")
+  void deletePlanDetail() {
+    // given
+    List<PlanDetail> planDetails = new ArrayList<>();
+    planDetails.add(planDetail);
+
+    when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
+    when(planDetailRepository.findById(1L)).thenReturn(Optional.of(planDetail));
+    plan.setPlanDetails(planDetails);
+
+    // when
+    planDetailService.deletePlanDetail(1L, 1L, "1");
+
+    // then
+    verify(planDetailRepository).delete(planDetail);
+  }
+
+}

--- a/src/test/java/com/eunsun/travel_mate/service/PlanServiceTest.java
+++ b/src/test/java/com/eunsun/travel_mate/service/PlanServiceTest.java
@@ -1,0 +1,192 @@
+package com.eunsun.travel_mate.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eunsun.travel_mate.domain.Plan;
+import com.eunsun.travel_mate.domain.User;
+import com.eunsun.travel_mate.dto.request.CreatePlanRequest;
+import com.eunsun.travel_mate.dto.request.UpdatePlanRequestDto;
+import com.eunsun.travel_mate.dto.response.CheckPlanResponseDto;
+import com.eunsun.travel_mate.dto.response.CreatePlanResponseDto;
+import com.eunsun.travel_mate.dto.response.UpdatePlanResponseDto;
+import com.eunsun.travel_mate.repository.jpa.PlanRepository;
+import com.eunsun.travel_mate.repository.jpa.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PlanServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PlanRepository planRepository;
+
+  @InjectMocks
+  private PlanService planService;
+
+  @Test
+  @DisplayName("일정표 생성 테스트")
+  void createPlan() {
+    // given
+    CreatePlanRequest createPlanRequest = new CreatePlanRequest();
+    createPlanRequest.setTitle("제주도 여행");
+    createPlanRequest.setStartDate(LocalDate.of(2024, 7, 1));
+    createPlanRequest.setEndDate(LocalDate.of(2024, 7, 10));
+
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(1L);
+
+    // when
+    when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(mockUser));
+
+    CreatePlanResponseDto response = planService.createPlan(createPlanRequest, "1");
+
+    // then
+    assertNotNull(response);
+    assertEquals("여행 일정표 생성 성공", response.getMessage());
+    verify(planRepository, times(1)).save(any(Plan.class));
+  }
+
+  @Test
+  @DisplayName("일정표 조회 테스트")
+  void getPlan() {
+    // given
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(1L);
+
+    Plan mockPlan = mock(Plan.class);
+    when(mockPlan.getPlanId()).thenReturn(1L);
+    when(mockPlan.getTitle()).thenReturn("제주도 여행");
+    when(mockPlan.getUser()).thenReturn(mockUser);
+
+    // when
+    when(planRepository.findById(any())).thenReturn(Optional.of(mockPlan));
+
+    CheckPlanResponseDto response = planService.getPlan(1L, "1");
+
+    // then
+    assertNotNull(response);
+    assertEquals("제주도 여행", response.getTitle());
+    verify(planRepository, times(1)).findById(any());
+  }
+
+  @Test
+  @DisplayName("일정표 수정 테스트")
+  void updatePlan() {
+    // given
+    User mockUser = new User();
+    mockUser.setUserId(1L);
+
+    Plan mockPlan = new Plan();
+    mockPlan.setPlanId(1L);
+    mockPlan.setUser(mockUser);
+    mockPlan.setTitle("제주도 여행");
+    mockPlan.setStartDate(LocalDate.of(2024, 7, 1));
+    mockPlan.setEndDate(LocalDate.of(2024, 7, 10));
+
+    UpdatePlanRequestDto updatePlanRequestDto = new UpdatePlanRequestDto();
+    updatePlanRequestDto.setTitle("부산 여행");
+    updatePlanRequestDto.setStartDate(LocalDate.of(2024, 7, 5));
+    updatePlanRequestDto.setEndDate(LocalDate.of(2024, 7, 15));
+
+    // when
+    when(planRepository.findById(any(Long.class))).thenReturn(Optional.of(mockPlan));
+
+    UpdatePlanResponseDto response = planService.updatePlan(1L, "1", updatePlanRequestDto);
+
+    // then
+    assertNotNull(response);
+    assertEquals("부산 여행", response.getTitle());
+    assertEquals(LocalDate.of(2024, 7, 5), response.getStartDate());
+    assertEquals(LocalDate.of(2024, 7, 15), response.getEndDate());
+    verify(planRepository, times(1)).findById(any(Long.class));
+  }
+
+
+  @Test
+  @DisplayName("일정표 삭제 테스트")
+  void deletePlan() {
+    // given
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(1L);
+
+    Plan mockPlan = mock(Plan.class);
+    when(mockPlan.getUser()).thenReturn(mockUser);
+
+    // when
+    when(planRepository.findById(any())).thenReturn(Optional.of(mockPlan));
+
+    // then
+    assertDoesNotThrow(() -> planService.deletePlan(1L, "1"));
+    verify(planRepository, times(1)).delete(any(Plan.class));
+  }
+
+  @Test
+  @DisplayName("인증 실패 테스트")
+  void authenticationFailureTest() {
+    // given
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(2L); // 다른 사용자 ID로 설정
+
+    Plan mockPlan = mock(Plan.class);
+    when(mockPlan.getUser()).thenReturn(mockUser);
+
+    // when
+    when(planRepository.findById(any())).thenReturn(Optional.of(mockPlan));
+
+    // then
+    assertThrows(IllegalArgumentException.class, () -> planService.deletePlan(1L, "1"));
+  }
+
+  @Test
+  @DisplayName("잘못된 입력값 테스트")
+  void invalidInputTest() {
+    // given
+    CreatePlanRequest createPlanRequest = new CreatePlanRequest();
+    createPlanRequest.setTitle(null); // 잘못된 입력값
+
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(1L);
+
+    // when
+    when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(mockUser));
+
+    // then
+    assertThrows(IllegalArgumentException.class, () -> planService.createPlan(createPlanRequest, "1"));
+  }
+
+  @Test
+  @DisplayName("리포지토리 예외 테스트")
+  void repositoryExceptionTest() {
+    // given
+    CreatePlanRequest createPlanRequest = new CreatePlanRequest();
+    createPlanRequest.setTitle("강원도 여행");
+    createPlanRequest.setStartDate(LocalDate.of(2024, 7, 1));
+    createPlanRequest.setEndDate(LocalDate.of(2024, 7, 10));
+
+    // when
+    when(userRepository.findById(any(Long.class))).thenThrow(new RuntimeException("Repository Exception"));
+
+    // then
+    assertThrows(RuntimeException.class, () -> planService.createPlan(createPlanRequest, "1"));
+  }
+}

--- a/src/test/java/com/eunsun/travel_mate/service/PlanServiceTest.java
+++ b/src/test/java/com/eunsun/travel_mate/service/PlanServiceTest.java
@@ -93,15 +93,15 @@ class PlanServiceTest {
   @DisplayName("일정표 수정 테스트")
   void updatePlan() {
     // given
-    User mockUser = new User();
-    mockUser.setUserId(1L);
+    User mockUser = mock(User.class);
+    when(mockUser.getUserId()).thenReturn(1L);
 
-    Plan mockPlan = new Plan();
-    mockPlan.setPlanId(1L);
-    mockPlan.setUser(mockUser);
-    mockPlan.setTitle("제주도 여행");
-    mockPlan.setStartDate(LocalDate.of(2024, 7, 1));
-    mockPlan.setEndDate(LocalDate.of(2024, 7, 10));
+    Plan mockPlan = mock(Plan.class);
+    when(mockPlan.getPlanId()).thenReturn(1L);
+    when(mockPlan.getUser()).thenReturn(mockUser);
+    when(mockPlan.getTitle()).thenReturn("제주도 여행");
+    when(mockPlan.getStartDate()).thenReturn(LocalDate.of(2024, 7, 1));
+    when(mockPlan.getEndDate()).thenReturn(LocalDate.of(2024, 7, 10));
 
     UpdatePlanRequestDto updatePlanRequestDto = new UpdatePlanRequestDto();
     updatePlanRequestDto.setTitle("부산 여행");
@@ -110,6 +110,9 @@ class PlanServiceTest {
 
     // when
     when(planRepository.findById(any(Long.class))).thenReturn(Optional.of(mockPlan));
+    when(mockPlan.getTitle()).thenReturn("부산 여행");
+    when(mockPlan.getStartDate()).thenReturn(LocalDate.of(2024, 7, 5));
+    when(mockPlan.getEndDate()).thenReturn(LocalDate.of(2024, 7, 15));
 
     UpdatePlanResponseDto response = planService.updatePlan(1L, "1", updatePlanRequestDto);
 
@@ -119,8 +122,10 @@ class PlanServiceTest {
     assertEquals(LocalDate.of(2024, 7, 5), response.getStartDate());
     assertEquals(LocalDate.of(2024, 7, 15), response.getEndDate());
     verify(planRepository, times(1)).findById(any(Long.class));
+    verify(mockPlan).setTitle("부산 여행");
+    verify(mockPlan).setStartDate(LocalDate.of(2024, 7, 5));
+    verify(mockPlan).setEndDate(LocalDate.of(2024, 7, 15));
   }
-
 
   @Test
   @DisplayName("일정표 삭제 테스트")


### PR DESCRIPTION
### 변경사항

**AS-IS**

- 여행 일정표 생성, 수정, 삭제, 조회 기능 없음
- 여행 상세 일정표 생성, 삭제, 수정 기능 없음

**TO-BE**

- [x] 여행 일정표 생성 기능 구현
(여행 일정표에는 제목, 여행 시작 날짜, 여행 종료 날짜 정보 포함)

- [x] 여행 일정표 수정 기능 구현
- [x] 여행 일정표 삭제 기능 구현 
(여행 상세 일정 포함 삭제)

- [x] 여행 일정표 조회 기능 구현 
(여행 상세 일정 포함 조회)

- [x] 여행 상세 일정표 생성 기능 구현
(여행 상세 일정표에는 여행지 정보, 시작 시간, 종료 시간, 메모 정보 포함)

- [x] 여행 상세 일정표 수정 기능 구현
- [x] 여행 상세 일정표 삭제 기능 구현 
(상세 일정을 삭제해도 여행 일정표는 유지)

### 테스트

- [x] 테스트 코드
- [x] API 테스트 